### PR TITLE
Optimize some memory initialization

### DIFF
--- a/src/dev/mcd.c
+++ b/src/dev/mcd.c
@@ -345,10 +345,8 @@ struct mcd_state* mcd_attach(struct ps2_sio2* sio2, int port, const char* path) 
     if (!file)
         return NULL;
 
-    struct mcd_state* mcd = malloc(sizeof(struct mcd_state));
+    struct mcd_state* mcd = calloc(1, sizeof(struct mcd_state));
     struct sio2_device dev;
-
-    memset(mcd, 0, sizeof(struct mcd_state));
 
     // Get memcard size
     fseek(file, 0, SEEK_END);

--- a/src/dev/ps1_mcd.c
+++ b/src/dev/ps1_mcd.c
@@ -158,10 +158,8 @@ struct ps1_mcd_state* ps1_mcd_attach(struct ps2_sio2* sio2, int port, const char
     if (!file)
         return NULL;
 
-    struct ps1_mcd_state* mcd = malloc(sizeof(struct ps1_mcd_state));
+    struct ps1_mcd_state* mcd = calloc(1, sizeof(struct ps1_mcd_state));
     struct sio2_device dev;
-
-    memset(mcd, 0, sizeof(struct ps1_mcd_state));
 
     mcd->file = file;
     mcd->flag = 0x08;

--- a/src/gs/renderer/hardware.hpp
+++ b/src/gs/renderer/hardware.hpp
@@ -90,7 +90,7 @@ public:
     }
 
     virtual bool on_label(uint64_t payload) override {
-        return ps2_gs_write_label(m_gs, payload);;
+        return ps2_gs_write_label(m_gs, payload);
     }
 };
 

--- a/src/iop/disc.c
+++ b/src/iop/disc.c
@@ -164,9 +164,7 @@ struct disc_state* disc_open(const char* path) {
     if (ext == DISC_EXT_UNSUPPORTED)
         return NULL;
 
-    struct disc_state* s = malloc(sizeof(struct disc_state));
-
-    memset(s, 0, sizeof(struct disc_state));
+    struct disc_state* s = calloc(1, sizeof(struct disc_state));
 
     s->layer2_lba = 0;
     s->ext = ext;

--- a/src/ps2_iso9660.c
+++ b/src/ps2_iso9660.c
@@ -25,9 +25,7 @@ struct iso9660_state* iso9660_open(const char* path) {
     if (!file)
         return NULL;
 
-    struct iso9660_state* iso = malloc(sizeof(struct iso9660_state));
-
-    memset(iso, 0, sizeof(struct iso9660_state));
+    struct iso9660_state* iso = calloc(1, sizeof(struct iso9660_state));
 
     iso->file = file;
 


### PR DESCRIPTION
Replace some `malloc` by `calloc` for initializing everything to zero without making 2 calls to the standard library.

Tested on Windows 11 and Arch Linux with no issue (Resident Evil 4)